### PR TITLE
coach teams table

### DIFF
--- a/apps/web/src/app/dashboard/coaches/teams/page.tsx
+++ b/apps/web/src/app/dashboard/coaches/teams/page.tsx
@@ -1,0 +1,64 @@
+import { Suspense } from "react";
+
+import MainLayout from "@/components/layout/main-layout";
+
+import { prefetchCoachTeamsWithFacetedServer } from "@/features/coach-teams/actions/getcoach-teams";
+import CoachTeamsContent from "@/features/coach-teams/components/coach-teams.content";
+import CoachTeamsHeader from "@/features/coach-teams/layout/coach-teams.header";
+
+import {
+	dehydrate,
+	HydrationBoundary,
+	QueryClient,
+} from "@tanstack/react-query";
+
+export default function CoachTeamsPage() {
+	return (
+		<Suspense fallback={<div>Loading...</div>}>
+			<CoachTeamsPageAsync />
+		</Suspense>
+	);
+}
+
+async function CoachTeamsPageAsync() {
+	const queryClient = new QueryClient();
+
+	// Default filters for initial load
+	const defaultFilters: any[] = [];
+	const defaultSorting: any[] = [];
+
+	// Create query keys directly (matching client-side keys)
+	const facetedColumns: string[] = [];
+	const combinedDataKey = [
+		"coach-teams",
+		"list",
+		"tableWithFaceted",
+		defaultFilters,
+		0,
+		25,
+		defaultSorting,
+		facetedColumns,
+	];
+
+	// Prefetch optimized combined data using server-side functions
+	await queryClient.prefetchQuery({
+		queryKey: combinedDataKey,
+		queryFn: () =>
+			prefetchCoachTeamsWithFacetedServer(
+				defaultFilters,
+				0,
+				25,
+				defaultSorting,
+				facetedColumns,
+			),
+		staleTime: 2 * 60 * 1000,
+	});
+
+	return (
+		<HydrationBoundary state={dehydrate(queryClient)}>
+			<MainLayout headers={[<CoachTeamsHeader key="coach-teams-header" />]}>
+				<CoachTeamsContent />
+			</MainLayout>
+		</HydrationBoundary>
+	);
+}

--- a/apps/web/src/components/sidebar/app-sidebar.tsx
+++ b/apps/web/src/components/sidebar/app-sidebar.tsx
@@ -2,7 +2,6 @@
 
 import type * as React from "react";
 
-import { usePathname } from "next/navigation";
 
 // Use Better Auth's built-in type inference
 import type { authClient } from "@/lib/auth-client";
@@ -23,25 +22,12 @@ import {
 } from "@/components/ui/sidebar";
 
 import {
-	Activity,
 	ArrowLeft,
-	BrickWallFireIcon,
-	CheckSquare,
-	Cog,
-	CreditCard,
-	DollarSign,
-	FileText,
-	FocusIcon,
+	BrickWallFireIcon, CreditCard, FocusIcon,
 	GoalIcon,
-	InboxIcon,
-	MessageSquare,
-	Package,
-	Phone,
-	Settings,
+	InboxIcon, Settings,
 	ShieldCheckIcon,
-	Star,
-	Tag,
-	Users,
+	Star, Users
 } from "lucide-react";
 import { NavMain } from "./nav-main";
 
@@ -161,6 +147,10 @@ export function AppSidebar({
 					{
 						title: "Coaches",
 						url: "/dashboard/coaches",
+					},
+					{
+						title: "Teams",
+						url: "/dashboard/coaches/teams",
 					},
 					{
 						title: "Premier Coaches",

--- a/apps/web/src/features/coach-teams/actions/getcoach-teams.ts
+++ b/apps/web/src/features/coach-teams/actions/getcoach-teams.ts
@@ -246,7 +246,7 @@ export async function getCoachTeamsWithFaceted(
 			facetedColumns.map(async (columnId) => {
 				let facetQuery = supabase
 					.from("coach_teams")
-					.select(columnId, { count: "exact" });
+					.select(`${columnId}, count:${columnId}.count()`, { head: false });
 
 				// Apply existing filters (excluding the column we're faceting)
 				filters
@@ -323,13 +323,14 @@ export async function getCoachTeamsWithFaceted(
 					return;
 				}
 
-				// Convert to Map format
+				// Convert server-aggregated data to Map format
 				const facetMap = new Map<string, number>();
 				facetData?.forEach((item: any) => {
 					const value = item[columnId];
-					if (value) {
+					const count = item.count;
+					if (value && count) {
 						const key = String(value);
-						facetMap.set(key, (facetMap.get(key) || 0) + 1);
+						facetMap.set(key, count);
 					}
 				});
 
@@ -356,7 +357,7 @@ export async function getCoachTeamsFaceted(columnId: string, filters: any[] = []
 	try {
 		const supabase = await createClient();
 
-		let query = supabase.from("coach_teams").select(columnId, { count: "exact" });
+		let query = supabase.from("coach_teams").select(`${columnId}, count:${columnId}.count()`, { head: false });
 
 		// Apply existing filters (excluding the column we're faceting)
 		filters
@@ -422,13 +423,14 @@ export async function getCoachTeamsFaceted(columnId: string, filters: any[] = []
 			return new Map<string, number>();
 		}
 
-		// Convert to Map format
+		// Convert server-aggregated data to Map format
 		const facetedMap = new Map<string, number>();
 		data?.forEach((item: any) => {
 			const value = item[columnId];
-			if (value) {
+			const count = item.count;
+			if (value && count) {
 				const key = String(value);
-				facetedMap.set(key, (facetedMap.get(key) || 0) + 1);
+				facetedMap.set(key, count);
 			}
 		});
 

--- a/apps/web/src/features/coach-teams/actions/getcoach-teams.ts
+++ b/apps/web/src/features/coach-teams/actions/getcoach-teams.ts
@@ -1,0 +1,474 @@
+"use server";
+
+import { createClient } from "@/utils/supabase/server";
+
+export async function getCoachTeam(id: string) {
+	try {
+		const supabase = await createClient();
+
+		// Fetch coach team with related data
+		const { data: coachTeam, error } = await supabase
+			.from("coach_teams")
+			.select(`
+				*,
+				premier_coach:team_members!coach_teams_premier_coach_id_fkey (
+					id,
+					name,
+					user:user!team_members_user_id_fkey (
+						id,
+						name,
+						email
+					)
+				),
+				coach:team_members!coach_teams_coach_id_fkey (
+					id,
+					name,
+					user:user!team_members_user_id_fkey (
+						id,
+						name,
+						email
+					)
+				)
+			`)
+			.eq("id", id)
+			.single();
+
+		if (error) {
+			console.error("Error fetching coach team:", error);
+			return null;
+		}
+
+		return coachTeam;
+	} catch (error) {
+		console.error("Unexpected error in getCoachTeam:", error);
+		return null;
+	}
+}
+
+export async function getCoachTeamBasic(id: string) {
+	try {
+		const supabase = await createClient();
+
+		const { data: coachTeam, error } = await supabase
+			.from("coach_teams")
+			.select("*")
+			.eq("id", id)
+			.single();
+
+		if (error) {
+			console.error("Error fetching coach team basic data:", error);
+			return null;
+		}
+
+		return coachTeam;
+	} catch (error) {
+		console.error("Unexpected error in getCoachTeamBasic:", error);
+		return null;
+	}
+}
+
+export async function getAllCoachTeams() {
+	try {
+		const supabase = await createClient();
+
+		const { data: coachTeams, error } = await supabase
+			.from("coach_teams")
+			.select(`
+				*,
+				premier_coach:team_members!coach_teams_premier_coach_id_fkey (
+					id,
+					name,
+					user:user!team_members_user_id_fkey (
+						id,
+						name,
+						email
+					)
+				),
+				coach:team_members!coach_teams_coach_id_fkey (
+					id,
+					name,
+					user:user!team_members_user_id_fkey (
+						id,
+						name,
+						email
+					)
+				)
+			`)
+			.order("created_at", { ascending: false });
+
+		if (error) {
+			console.error("Error fetching coach teams:", error);
+			return [];
+		}
+
+		return coachTeams || [];
+	} catch (error) {
+		console.error("Unexpected error in getAllCoachTeams:", error);
+		return [];
+	}
+}
+
+export async function getCoachTeamsWithFilters(
+	filters: any[] = [],
+	page = 0,
+	pageSize = 25,
+	sorting: any[] = [],
+) {
+	try {
+		const supabase = await createClient();
+
+		let query = supabase.from("coach_teams").select(
+			`
+				*,
+				premier_coach:team_members!coach_teams_premier_coach_id_fkey (
+					id,
+					name,
+					user:user!team_members_user_id_fkey (
+						id,
+						name,
+						email
+					)
+				),
+				coach:team_members!coach_teams_coach_id_fkey (
+					id,
+					name,
+					user:user!team_members_user_id_fkey (
+						id,
+						name,
+						email
+					)
+				)
+			`,
+			{ count: "exact" },
+		);
+
+		// Apply filters with proper operator support
+		filters.forEach((filter) => {
+			if (filter.values && filter.values.length > 0) {
+				const values = filter.values;
+				const operator = filter.operator || "is";
+				const columnId = filter.columnId;
+
+				// Apply filter based on column type and operator
+				switch (columnId) {
+					case "premier_coach_id":
+					case "coach_id":
+						// Foreign key filters
+						if (operator === "is") {
+							query = query.eq(columnId, values[0]);
+						} else if (operator === "is not") {
+							query = query.not(columnId, "eq", values[0]);
+						} else if (operator === "is any of") {
+							query = query.in(columnId, values);
+						} else if (operator === "is none of") {
+							query = query.not(columnId, "in", `(${values.join(",")})`);
+						}
+						break;
+
+					case "created_at":
+					case "updated_at":
+						// Date fields - support various date operators
+						if (operator === "is") {
+							query = query.eq(columnId, values[0]);
+						} else if (operator === "is not") {
+							query = query.not(columnId, "eq", values[0]);
+						} else if (operator === "is before") {
+							query = query.lt(columnId, values[0]);
+						} else if (operator === "is on or before") {
+							query = query.lte(columnId, values[0]);
+						} else if (operator === "is after") {
+							query = query.gt(columnId, values[0]);
+						} else if (operator === "is on or after") {
+							query = query.gte(columnId, values[0]);
+						} else if (operator === "is between" && values.length === 2) {
+							query = query.gte(columnId, values[0]).lte(columnId, values[1]);
+						} else if (operator === "is not between" && values.length === 2) {
+							query = query.or(
+								`${columnId}.lt.${values[0]},${columnId}.gt.${values[1]}`,
+							);
+						}
+						break;
+				}
+			}
+		});
+
+		// Apply sorting
+		if (sorting.length > 0) {
+			const sort = sorting[0];
+			query = query.order(sort.id, { ascending: !sort.desc });
+		} else {
+			query = query.order("created_at", { ascending: false });
+		}
+
+		// Apply pagination
+		const from = page * pageSize;
+		const to = from + pageSize - 1;
+		query = query.range(from, to);
+
+		const { data, error, count } = await query;
+
+		if (error) {
+			console.error("Error fetching coach teams with filters:", error);
+			return { data: [], count: 0 };
+		}
+
+		return { data: data || [], count: count || 0 };
+	} catch (error) {
+		console.error("Unexpected error in getCoachTeamsWithFilters:", error);
+		return { data: [], count: 0 };
+	}
+}
+
+// Combined query for coach teams with faceted data - optimized single call
+export async function getCoachTeamsWithFaceted(
+	filters: any[] = [],
+	page = 0,
+	pageSize = 25,
+	sorting: any[] = [],
+	facetedColumns: string[] = [],
+) {
+	try {
+		const supabase = await createClient();
+
+		// Get main coach teams data
+		const coachTeamsResult = await getCoachTeamsWithFilters(
+			filters,
+			page,
+			pageSize,
+			sorting,
+		);
+
+		// Get faceted data for each requested column
+		const facetedData: Record<string, Map<string, number>> = {};
+
+		// Fetch faceted counts for each column in parallel
+		await Promise.all(
+			facetedColumns.map(async (columnId) => {
+				let facetQuery = supabase
+					.from("coach_teams")
+					.select(columnId, { count: "exact" });
+
+				// Apply existing filters (excluding the column we're faceting)
+				filters
+					.filter((filter) => filter.columnId !== columnId)
+					.forEach((filter) => {
+						if (filter.values && filter.values.length > 0) {
+							const values = filter.values;
+							const operator = filter.operator || "is";
+							const filterColumnId = filter.columnId;
+
+							// Apply same operator logic as main query
+							switch (filterColumnId) {
+								case "premier_coach_id":
+								case "coach_id":
+									// Foreign key filters
+									if (operator === "is") {
+										facetQuery = facetQuery.eq(filterColumnId, values[0]);
+									} else if (operator === "is not") {
+										facetQuery = facetQuery.not(filterColumnId, "eq", values[0]);
+									} else if (operator === "is any of") {
+										facetQuery = facetQuery.in(filterColumnId, values);
+									} else if (operator === "is none of") {
+										facetQuery = facetQuery.not(
+											filterColumnId,
+											"in",
+											`(${values.join(",")})`,
+										);
+									}
+									break;
+
+								case "created_at":
+								case "updated_at":
+									if (operator === "is") {
+										facetQuery = facetQuery.eq(filterColumnId, values[0]);
+									} else if (operator === "is not") {
+										facetQuery = facetQuery.not(
+											filterColumnId,
+											"eq",
+											values[0],
+										);
+									} else if (operator === "is before") {
+										facetQuery = facetQuery.lt(filterColumnId, values[0]);
+									} else if (operator === "is on or before") {
+										facetQuery = facetQuery.lte(filterColumnId, values[0]);
+									} else if (operator === "is after") {
+										facetQuery = facetQuery.gt(filterColumnId, values[0]);
+									} else if (operator === "is on or after") {
+										facetQuery = facetQuery.gte(filterColumnId, values[0]);
+									} else if (operator === "is between" && values.length === 2) {
+										facetQuery = facetQuery
+											.gte(filterColumnId, values[0])
+											.lte(filterColumnId, values[1]);
+									} else if (
+										operator === "is not between" &&
+										values.length === 2
+									) {
+										facetQuery = facetQuery.or(
+											`${filterColumnId}.lt.${values[0]},${filterColumnId}.gt.${values[1]}`,
+										);
+									}
+									break;
+							}
+						}
+					});
+
+				const { data: facetData, error: facetError } = await facetQuery;
+
+				if (facetError) {
+					console.error(
+						`Error fetching faceted data for ${columnId}:`,
+						facetError,
+					);
+					facetedData[columnId] = new Map();
+					return;
+				}
+
+				// Convert to Map format
+				const facetMap = new Map<string, number>();
+				facetData?.forEach((item: any) => {
+					const value = item[columnId];
+					if (value) {
+						const key = String(value);
+						facetMap.set(key, (facetMap.get(key) || 0) + 1);
+					}
+				});
+
+				facetedData[columnId] = facetMap;
+			}),
+		);
+
+		return {
+			coachTeams: coachTeamsResult.data,
+			totalCount: coachTeamsResult.count,
+			facetedData,
+		};
+	} catch (error) {
+		console.error("Unexpected error in getCoachTeamsWithFaceted:", error);
+		return {
+			coachTeams: [],
+			totalCount: 0,
+			facetedData: {},
+		};
+	}
+}
+
+export async function getCoachTeamsFaceted(columnId: string, filters: any[] = []) {
+	try {
+		const supabase = await createClient();
+
+		let query = supabase.from("coach_teams").select(columnId, { count: "exact" });
+
+		// Apply existing filters (excluding the column we're faceting)
+		filters
+			.filter((filter) => filter.columnId !== columnId)
+			.forEach((filter) => {
+				if (filter.values && filter.values.length > 0) {
+					const values = filter.values;
+					const operator = filter.operator || "is";
+					const filterColumnId = filter.columnId;
+
+					// Apply same operator logic as main query
+					switch (filterColumnId) {
+						case "premier_coach_id":
+						case "coach_id":
+							// Foreign key filters
+							if (operator === "is") {
+								query = query.eq(filterColumnId, values[0]);
+							} else if (operator === "is not") {
+								query = query.not(filterColumnId, "eq", values[0]);
+							} else if (operator === "is any of") {
+								query = query.in(filterColumnId, values);
+							} else if (operator === "is none of") {
+								query = query.not(
+									filterColumnId,
+									"in",
+									`(${values.join(",")})`,
+								);
+							}
+							break;
+
+						case "created_at":
+						case "updated_at":
+							if (operator === "is") {
+								query = query.eq(filterColumnId, values[0]);
+							} else if (operator === "is not") {
+								query = query.not(filterColumnId, "eq", values[0]);
+							} else if (operator === "is before") {
+								query = query.lt(filterColumnId, values[0]);
+							} else if (operator === "is on or before") {
+								query = query.lte(filterColumnId, values[0]);
+							} else if (operator === "is after") {
+								query = query.gt(filterColumnId, values[0]);
+							} else if (operator === "is on or after") {
+								query = query.gte(filterColumnId, values[0]);
+							} else if (operator === "is between" && values.length === 2) {
+								query = query
+									.gte(filterColumnId, values[0])
+									.lte(filterColumnId, values[1]);
+							} else if (operator === "is not between" && values.length === 2) {
+								query = query.or(
+									`${filterColumnId}.lt.${values[0]},${filterColumnId}.gt.${values[1]}`,
+								);
+							}
+							break;
+					}
+				}
+			});
+
+		const { data, error } = await query;
+
+		if (error) {
+			console.error("Error fetching faceted data:", error);
+			return new Map<string, number>();
+		}
+
+		// Convert to Map format
+		const facetedMap = new Map<string, number>();
+		data?.forEach((item: any) => {
+			const value = item[columnId];
+			if (value) {
+				const key = String(value);
+				facetedMap.set(key, (facetedMap.get(key) || 0) + 1);
+			}
+		});
+
+		return facetedMap;
+	} catch (error) {
+		console.error("Unexpected error in getCoachTeamsFaceted:", error);
+		return new Map<string, number>();
+	}
+}
+
+// Server-side prefetch functions for page-level prefetching
+export async function prefetchCoachTeamsTableDataServer(
+	filters: any[] = [],
+	page = 0,
+	pageSize = 25,
+	sorting: any[] = [],
+) {
+	return await getCoachTeamsWithFilters(filters, page, pageSize, sorting);
+}
+
+export async function prefetchCoachTeamsFacetedServer(
+	columnId: string,
+	filters: any[] = [],
+) {
+	return await getCoachTeamsFaceted(columnId, filters);
+}
+
+// Server-side prefetch for combined coach teams+faceted data
+export async function prefetchCoachTeamsWithFacetedServer(
+	filters: any[] = [],
+	page = 0,
+	pageSize = 25,
+	sorting: any[] = [],
+	facetedColumns: string[] = [],
+) {
+	return await getCoachTeamsWithFaceted(
+		filters,
+		page,
+		pageSize,
+		sorting,
+		facetedColumns,
+	);
+}

--- a/apps/web/src/features/coach-teams/components/coach-teams.content.tsx
+++ b/apps/web/src/features/coach-teams/components/coach-teams.content.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { CoachTeamsDataTable } from "./coach-teams.table";
+
+export default function CoachTeamsContent() {
+	return (
+		<div className="space-y-6 p-6">
+			<CoachTeamsDataTable />
+		</div>
+	);
+}

--- a/apps/web/src/features/coach-teams/components/coach-teams.table.tsx
+++ b/apps/web/src/features/coach-teams/components/coach-teams.table.tsx
@@ -99,7 +99,7 @@ const coachTeamTableColumns = [
 					table.getIsAllPageRowsSelected() ||
 					(table.getIsSomePageRowsSelected() && "indeterminate")
 				}
-				onCheckedChange={(value) => table.toggleAllRowsSelected(!!value)}
+				onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
 				aria-label="Select all"
 			/>
 		),

--- a/apps/web/src/features/coach-teams/components/coach-teams.table.tsx
+++ b/apps/web/src/features/coach-teams/components/coach-teams.table.tsx
@@ -1,0 +1,346 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import Link from "next/link";
+
+import type { Database } from "@/utils/supabase/database.types";
+
+import { DataTableFilter } from "@/components/data-table-filter";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { useUniversalTable } from "@/components/universal-data-table/hooks/use-universal-table";
+import {
+	UniversalTableFilterSkeleton,
+	UniversalTableSkeleton,
+} from "@/components/universal-data-table/table-skeleton";
+import { UniversalDataTable } from "@/components/universal-data-table/universal-data-table";
+import { UniversalDataTableWrapper } from "@/components/universal-data-table/universal-data-table-wrapper";
+import { createUniversalColumnHelper } from "@/components/universal-data-table/utils/column-helpers";
+
+import { createColumnHelper } from "@tanstack/react-table";
+import {
+	EditIcon,
+	EyeIcon,
+	PlusIcon,
+	TrashIcon,
+	UserIcon,
+} from "lucide-react";
+import { toast } from "sonner";
+import { useCoachTeamsWithFaceted } from "../queries/usecoach-teams";
+import { useQuery } from "@tanstack/react-query";
+import { createClient } from "@/utils/supabase/client";
+
+// Fetch all team members for filter options
+async function getAllTeamMembers() {
+	const supabase = createClient();
+	const { data, error } = await supabase
+		.from("team_members")
+		.select(`
+			id,
+			name,
+			user:user!team_members_user_id_fkey (
+				id,
+				name,
+				email
+			)
+		`)
+		.order("name", { ascending: true });
+
+	if (error) {
+		console.error("Error fetching team members:", error);
+		return [];
+	}
+
+	return data || [];
+}
+
+// Hook to fetch team members for filters
+function useTeamMembers() {
+	return useQuery({
+		queryKey: ["team-members", "all"],
+		queryFn: getAllTeamMembers,
+		staleTime: 5 * 60 * 1000, // 5 minutes
+	});
+}
+
+// Type for coach-team row from Supabase with relations
+type CoachTeamRow = Database["public"]["Tables"]["coach_teams"]["Row"] & {
+	premier_coach?: {
+		id: string;
+		name: string | null;
+		user: {
+			id: string;
+			name: string;
+			email: string;
+		} | null;
+	} | null;
+	coach?: {
+		id: string;
+		name: string | null;
+		user: {
+			id: string;
+			name: string;
+			email: string;
+		} | null;
+	} | null;
+};
+
+// Create column helper for TanStack table
+const columnHelper = createColumnHelper<CoachTeamRow>();
+
+// TanStack table column definitions
+const coachTeamTableColumns = [
+	columnHelper.display({
+		id: "select",
+		header: ({ table }) => (
+			<Checkbox
+				checked={
+					table.getIsAllPageRowsSelected() ||
+					(table.getIsSomePageRowsSelected() && "indeterminate")
+				}
+				onCheckedChange={(value) => table.toggleAllRowsSelected(!!value)}
+				aria-label="Select all"
+			/>
+		),
+		cell: ({ row }) => (
+			<Checkbox
+				checked={row.getIsSelected()}
+				onCheckedChange={(value) => row.toggleSelected(!!value)}
+				aria-label="Select row"
+			/>
+		),
+		enableSorting: false,
+		enableHiding: false,
+		enableColumnFilter: false,
+	}),
+	columnHelper.display({
+		id: "premier_coach",
+		header: "Premier Coach",
+		enableColumnFilter: false,
+		cell: ({ row }) => {
+			const premierCoach = row.original.premier_coach;
+			return (
+				<div className="text-sm">
+					{premierCoach?.name || "No premier coach"}
+				</div>
+			);
+		},
+	}),
+	columnHelper.display({
+		id: "coach",
+		header: "Coach",
+		enableColumnFilter: false,
+		cell: ({ row }) => {
+			const coach = row.original.coach;
+			return (
+				<div className="text-sm">
+					{coach?.name || "No coach"}
+				</div>
+			);
+		},
+	}),
+];
+
+// Filter configuration using universal column helper
+const universalColumnHelper = createUniversalColumnHelper<CoachTeamRow>();
+
+const coachTeamFilterConfig = [
+	universalColumnHelper
+		.option("premier_coach_id")
+		.displayName("Premier Coach")
+		.icon(UserIcon)
+		.build(),
+	universalColumnHelper
+		.option("coach_id")
+		.displayName("Coach")
+		.icon(UserIcon)
+		.build(),
+];
+
+function CoachTeamsTableContent({
+	filters,
+	setFilters,
+}: {
+	filters: any;
+	setFilters: any;
+}) {
+	const [currentPage, setCurrentPage] = useState(0);
+	const [sorting, setSorting] = useState<any[]>([]);
+	
+	// Fetch team members for filter options
+	const { data: teamMembers, isLoading: isLoadingTeamMembers } = useTeamMembers();
+
+	// Reset to first page when filters change
+	useEffect(() => {
+		setCurrentPage(0);
+	}, [filters]);
+
+	// Fetch coach teams data with faceted data in single optimized call
+	const {
+		data: coachTeamsWithFaceted,
+		isLoading,
+		isError,
+		error,
+	} = useCoachTeamsWithFaceted(
+		filters,
+		currentPage,
+		25,
+		sorting,
+		[], // columns to get faceted data for
+	);
+
+	// Extract data from combined result
+	const coachTeamsData = coachTeamsWithFaceted
+		? {
+				data: coachTeamsWithFaceted.coachTeams,
+				count: coachTeamsWithFaceted.totalCount,
+			}
+		: { data: [], count: 0 };
+
+	// Create dynamic filter config with team members options
+	const teamMemberOptions = teamMembers?.map(member => ({
+		value: member.id,
+		label: member.name || member.user?.name || member.user?.email || 'Unknown'
+	})) || [];
+
+	const dynamicFilterConfig = [
+		{
+			...universalColumnHelper
+				.option("premier_coach_id")
+				.displayName("Premier Coach")
+				.icon(UserIcon)
+				.build(),
+			options: teamMemberOptions,
+		},
+		{
+			...universalColumnHelper
+				.option("coach_id")
+				.displayName("Coach")
+				.icon(UserIcon)
+				.build(),
+			options: teamMemberOptions,
+		},
+	];
+
+	const rowActions = [
+		{
+			label: "View Details",
+			icon: EyeIcon,
+			onClick: () => {
+				// Placeholder
+				toast.info("View details coming soon");
+			},
+		},
+		{
+			label: "Edit",
+			icon: EditIcon,
+			onClick: () => {
+				// Placeholder
+				toast.info("Edit coming soon");
+			},
+		},
+		{
+			label: "Delete",
+			icon: TrashIcon,
+			variant: "destructive" as const,
+			onClick: () => {
+				// Placeholder
+				toast.info("Delete coming soon");
+			},
+		},
+	];
+
+	const { table, filterColumns, filterState, actions, strategy, totalCount } =
+		useUniversalTable<CoachTeamRow>({
+			data: coachTeamsData?.data || [],
+			totalCount: coachTeamsData?.count || 0,
+			columns: coachTeamTableColumns,
+			columnsConfig: dynamicFilterConfig,
+			filters,
+			onFiltersChange: setFilters,
+			faceted: {},
+			enableSelection: true,
+			pageSize: 25,
+			serverSide: true,
+			rowActions,
+			isLoading,
+			isError,
+			error,
+			onPaginationChange: (pageIndex) => {
+				setCurrentPage(pageIndex);
+			},
+			onSortingChange: setSorting,
+		});
+
+	// Check if filter options are still loading
+	const isFilterDataPending = isLoadingTeamMembers;
+
+	if (isError) {
+		return (
+			<div className="w-full">
+				<div className="space-y-2 text-center">
+					<p className="text-red-600">
+						Error loading coach teams: {error?.message}
+					</p>
+					<p className="text-muted-foreground text-sm">
+						Please check your database connection and try again.
+					</p>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="w-full">
+			<div className="flex items-center gap-2 pb-4">
+				{isFilterDataPending ? (
+					<UniversalTableFilterSkeleton />
+				) : (
+					<DataTableFilter
+						filters={filterState}
+						columns={filterColumns}
+						actions={actions}
+						strategy={strategy}
+					/>
+				)}
+			</div>
+
+			{isLoading ? (
+				<UniversalTableSkeleton
+					numCols={coachTeamTableColumns.length}
+					numRows={10}
+				/>
+			) : (
+				<UniversalDataTable
+					table={table}
+					actions={actions}
+					totalCount={totalCount}
+					rowActions={rowActions}
+					emptyStateMessage="No coach teams found matching your filters"
+					emptyStateAction={
+						<Button size="sm" className="gap-2" asChild>
+							<Link href="#">
+								<PlusIcon className="h-4 w-4" />
+								Add Coach Team
+							</Link>
+						</Button>
+					}
+				/>
+			)}
+		</div>
+	);
+}
+
+export function CoachTeamsDataTable() {
+	return (
+		<UniversalDataTableWrapper<CoachTeamRow>
+			table="coach-teams"
+			columns={coachTeamTableColumns}
+			columnsConfig={coachTeamFilterConfig}
+			urlStateKey="coachTeamFilters"
+		>
+			{(state) => <CoachTeamsTableContent {...state} />}
+		</UniversalDataTableWrapper>
+	);
+}

--- a/apps/web/src/features/coach-teams/layout/coach-teams.header.tsx
+++ b/apps/web/src/features/coach-teams/layout/coach-teams.header.tsx
@@ -1,0 +1,23 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+
+import { UserRoundPlusIcon } from "lucide-react";
+
+export default function CoachTeamsHeader() {
+	return (
+		<div className="sticky top-0 z-10 flex h-[45px] flex-shrink-0 items-center justify-between border-border border-b px-4 py-2 lg:px-6">
+			<div className="flex items-center gap-2">
+				<SidebarTrigger />
+				<h1 className="font-medium text-[13px] ">Coach Teams</h1>
+			</div>
+			<Button asChild>
+				<Link href="#" className="flex items-center gap-2">
+					<UserRoundPlusIcon className="mr-[6px] h-4 w-4" />
+					Add Coach Team
+				</Link>
+			</Button>
+		</div>
+	);
+}

--- a/apps/web/src/features/coach-teams/queries/usecoach-teams.ts
+++ b/apps/web/src/features/coach-teams/queries/usecoach-teams.ts
@@ -1,0 +1,249 @@
+"use client";
+
+import type { FiltersState } from "@/components/data-table-filter/core/types";
+
+import {
+	getAllCoachTeams,
+	getCoachTeam,
+	getCoachTeamBasic,
+	getCoachTeamsFaceted,
+	getCoachTeamsWithFaceted,
+	getCoachTeamsWithFilters,
+} from "@/features/coach-teams/actions/getcoach-teams";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { SortingState } from "@tanstack/react-table";
+
+// Query keys
+export const coachTeamQueries = {
+	all: ["coach-teams"] as const,
+	lists: () => [...coachTeamQueries.all, "list"] as const,
+	list: (filters: Record<string, unknown>) =>
+		[...coachTeamQueries.lists(), filters] as const,
+	tableData: (
+		filters: FiltersState,
+		page: number,
+		pageSize: number,
+		sorting: SortingState,
+	) =>
+		[
+			...coachTeamQueries.lists(),
+			"table",
+			filters,
+			page,
+			pageSize,
+			sorting,
+		] as const,
+	tableDataWithFaceted: (
+		filters: FiltersState,
+		page: number,
+		pageSize: number,
+		sorting: SortingState,
+		facetedColumns: string[],
+	) =>
+		[
+			...coachTeamQueries.lists(),
+			"tableWithFaceted",
+			filters,
+			page,
+			pageSize,
+			sorting,
+			facetedColumns,
+		] as const,
+	faceted: (columnId: string, filters: FiltersState) =>
+		[...coachTeamQueries.lists(), "faceted", columnId, filters] as const,
+	details: () => [...coachTeamQueries.all, "detail"] as const,
+	detail: (id: string) => [...coachTeamQueries.details(), id] as const,
+	basic: (id: string) => [...coachTeamQueries.all, "basic", id] as const,
+};
+
+// Query hooks
+export function useCoachTeams() {
+	return useQuery({
+		queryKey: coachTeamQueries.lists(),
+		queryFn: getAllCoachTeams,
+		staleTime: 5 * 60 * 1000, // 5 minutes
+	});
+}
+
+// Enhanced hook for table data with filtering, pagination, sorting
+export function useCoachTeamsTableData(
+	filters: FiltersState = [],
+	page = 0,
+	pageSize = 25,
+	sorting: SortingState = [],
+) {
+	return useQuery({
+		queryKey: coachTeamQueries.tableData(filters, page, pageSize, sorting),
+		queryFn: () => getCoachTeamsWithFilters(filters, page, pageSize, sorting),
+		staleTime: 2 * 60 * 1000, // 2 minutes
+	});
+}
+
+// Faceted data query for filters
+export function useCoachTeamsFaceted(
+	columnId: string,
+	filters: FiltersState = [],
+) {
+	return useQuery({
+		queryKey: coachTeamQueries.faceted(columnId, filters),
+		queryFn: () => getCoachTeamsFaceted(columnId, filters),
+		staleTime: 5 * 60 * 1000, // 5 minutes
+	});
+}
+
+// Combined hook for table data with faceted data - optimized single call
+export function useCoachTeamsWithFaceted(
+	filters: FiltersState = [],
+	page = 0,
+	pageSize = 25,
+	sorting: SortingState = [],
+	facetedColumns: string[] = [],
+) {
+	return useQuery({
+		queryKey: coachTeamQueries.tableDataWithFaceted(
+			filters,
+			page,
+			pageSize,
+			sorting,
+			facetedColumns,
+		),
+		queryFn: () =>
+			getCoachTeamsWithFaceted(filters, page, pageSize, sorting, facetedColumns),
+		staleTime: 2 * 60 * 1000, // 2 minutes
+	});
+}
+
+export function useCoachTeam(id: string) {
+	return useQuery({
+		queryKey: coachTeamQueries.detail(id),
+		queryFn: () => getCoachTeam(id),
+		enabled: !!id,
+		staleTime: 2 * 60 * 1000, // 2 minutes
+	});
+}
+
+export function useCoachTeamBasic(id: string) {
+	return useQuery({
+		queryKey: coachTeamQueries.basic(id),
+		queryFn: () => getCoachTeamBasic(id),
+		enabled: !!id,
+		staleTime: 2 * 60 * 1000, // 2 minutes
+	});
+}
+
+// Mutation hooks - placeholders for now
+export function useCreateCoachTeam() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (data: any) => {
+			// Placeholder implementation
+			throw new Error("Create coach team not implemented");
+		},
+		onSuccess: () => {
+			// Invalidate and refetch coach teams list
+			queryClient.invalidateQueries({ queryKey: coachTeamQueries.lists() });
+		},
+	});
+}
+
+export function useUpdateCoachTeam() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (data: any) => {
+			// Placeholder implementation
+			throw new Error("Update coach team not implemented");
+		},
+		onSuccess: (result, variables) => {
+			// Invalidate and refetch both the list and the specific coach team
+			queryClient.invalidateQueries({ queryKey: coachTeamQueries.lists() });
+			queryClient.invalidateQueries({
+				queryKey: coachTeamQueries.detail(variables.id),
+			});
+			queryClient.invalidateQueries({
+				queryKey: coachTeamQueries.basic(variables.id),
+			});
+		},
+	});
+}
+
+export function useDeleteCoachTeam() {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: (id: string) => {
+			// Placeholder implementation
+			throw new Error("Delete coach team not implemented");
+		},
+		onSuccess: (result, deletedId) => {
+			// Remove the deleted coach team from the cache
+			queryClient.removeQueries({ queryKey: coachTeamQueries.detail(deletedId) });
+			queryClient.removeQueries({ queryKey: coachTeamQueries.basic(deletedId) });
+
+			// Invalidate the coach teams list to refetch
+			queryClient.invalidateQueries({ queryKey: coachTeamQueries.lists() });
+		},
+	});
+}
+
+// Prefetch helpers
+export function prefetchCoachTeams(
+	queryClient: ReturnType<typeof useQueryClient>,
+) {
+	return queryClient.prefetchQuery({
+		queryKey: coachTeamQueries.lists(),
+		queryFn: getAllCoachTeams,
+		staleTime: 5 * 60 * 1000,
+	});
+}
+
+export function prefetchCoachTeam(
+	queryClient: ReturnType<typeof useQueryClient>,
+	id: string,
+) {
+	return queryClient.prefetchQuery({
+		queryKey: coachTeamQueries.detail(id),
+		queryFn: () => getCoachTeam(id),
+		staleTime: 2 * 60 * 1000,
+	});
+}
+
+export function prefetchCoachTeamBasic(
+	queryClient: ReturnType<typeof useQueryClient>,
+	id: string,
+) {
+	return queryClient.prefetchQuery({
+		queryKey: coachTeamQueries.basic(id),
+		queryFn: () => getCoachTeamBasic(id),
+		staleTime: 2 * 60 * 1000,
+	});
+}
+
+// Prefetch helpers for new table data approach
+export function prefetchCoachTeamsTableData(
+	queryClient: ReturnType<typeof useQueryClient>,
+	filters: FiltersState = [],
+	page = 0,
+	pageSize = 25,
+	sorting: SortingState = [],
+) {
+	return queryClient.prefetchQuery({
+		queryKey: coachTeamQueries.tableData(filters, page, pageSize, sorting),
+		queryFn: () => getCoachTeamsWithFilters(filters, page, pageSize, sorting),
+		staleTime: 2 * 60 * 1000,
+	});
+}
+
+export function prefetchCoachTeamsFaceted(
+	queryClient: ReturnType<typeof useQueryClient>,
+	columnId: string,
+	filters: FiltersState = [],
+) {
+	return queryClient.prefetchQuery({
+		queryKey: coachTeamQueries.faceted(columnId, filters),
+		queryFn: () => getCoachTeamsFaceted(columnId, filters),
+		staleTime: 5 * 60 * 1000,
+	});
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a new Coach Teams page with a server-powered data table.
  - Supports filtering (by premier coach and coach), faceted counts, sorting, pagination, and multi-select.
  - Added row actions (View, Edit, Delete) and an “Add Coach Team” action.
- Navigation
  - Added “Teams” under Coaches in the sidebar, linking to the new page.
- UI/UX
  - Includes a sticky header, loading skeletons, and user-visible error states for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->